### PR TITLE
Check for lowercase authorization header

### DIFF
--- a/libraries/wp-api-jwt-auth/public/class-jwt-auth-public.php
+++ b/libraries/wp-api-jwt-auth/public/class-jwt-auth-public.php
@@ -235,6 +235,9 @@ class Jwt_Auth_Public
         if (!$auth) {
             $auth = isset(apache_request_headers()['Authorization']) ? apache_request_headers()['Authorization'] : false;
         }
+        if (!$auth) {
+            $auth = isset(apache_request_headers()['authorization']) ? apache_request_headers()['authorization'] : false;
+        }
 
         if (!$auth) {
             return new WP_Error(


### PR DESCRIPTION
Background:
PHP seems to have a bug when using Apache as the web server that HTTP headers are case sensitive. Since the mobile app is lowercasing all authorization headers, this is causing issues using Apache-based sites with the mobile app.

See https://bugs.php.net/bug.php?id=77953

This update checks for the lowercased variant of the Authorization HTTP header when authorizing requests.