### PR TITLE
Handle expo tokens that are stored as an array instead of string

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -159,7 +159,11 @@ class DT_Mobile_App_Plugin_Functions
                 // Subscribe the recipient to the server
                 if ( isset( $value["token"] ) ) {
                     try {
-                        $expo->subscribe( $channel, $value["token"] );
+                        if ( is_string( $value["token"] ) ) {
+                            $expo->subscribe( $channel, $value["token"] );
+                        } else if ( is_array( $value["token"] ) && array_key_exists( "data", $value["token"] ) ) {
+                            $expo->subscribe( $channel, $value["token"]["data"] );
+                        }
                     } catch ( ExponentPhpSDK\Exceptions\ExpoRegistrarException $e ){
                         if ( $e->getCode() === 422 ){
                             unset( $push_tokens[$device_id] );


### PR DESCRIPTION
Tracked down some errors when creating contacts via the API that led to this error:

```
PHP Fatal error: Uncaught TypeError: Argument 1 passed to ExponentPhpSDK\\ExpoRegistrar::isValidExpoPushToken() must be of the type string, array given, called in /nas/content/live/dtsite/wp-content/plugins/disciple-tools-mobile-app-plugin-master/vendor/alymosul/exponent-server-sdk-php/lib/ExpoRegistrar.php on line 37 and defined in /nas/content/live/dtsite/wp-content/plugins/disciple-tools-mobile-app-plugin-master/vendor/alymosul/exponent-server-sdk-php/lib/ExpoRegistrar.php:114
Stack trace:
#0 /nas/content/live/dtsite/wp-content/plugins/disciple-tools-mobile-app-plugin-master/vendor/alymosul/exponent-server-sdk-php/lib/ExpoRegistrar.php(37): ExponentPhpSDK\\ExpoRegistrar->isValidExpoPushToken(Array)
#1 /nas/content/live/dtsite/wp-content/plugins/disciple-tools-mobile-app-plugin-master/vendor/alymosul/exponent-server-sdk-php/lib/Expo.php(61): ExponentPhpSDK\\ExpoRegistrar->registerInterest('new_assigned103...', Array)
#2 /nas/content/live/dtsite/wp-content/plugins/disciple-tools-mobile-app-plugin-master/includes/functions. in /nas/content/live/dtsite/wp-content/plugins/disciple-tools-mobile-app-plugin-master/vendor/alymosul/exponent-server-sdk-php/lib/ExpoRegistrar.php on line 114
```

After looking in my database, the value of the `wp_dt_user_options` for the relevant user showed a token value that was an array as opposed to the expected string (the `token` property is assumed to be a string):

```
Array
(
    [Google:Pixel 3:2015:Android:11] => Array
        (
            [token] => Array
                (
                    [type] => expo
                    [data] => ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]
                )

        )

)
```

As such, I added in a check to see if the user option is a string or an array. I am guessing it has changed over time, so this should support both strings and associative arrays.